### PR TITLE
Handle video note message summaries

### DIFF
--- a/app/src/main/java/com/gohj99/tgwear/utils/notification/TgApiForPushNotification.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/notification/TgApiForPushNotification.kt
@@ -896,6 +896,9 @@ class TgApiForPushNotification(private val context: Context) {
                 val text = context.getString(R.string.Video) + " " + caption
                 if (text.length > maxText) text.take(maxText) + "..." else text
             }
+            is TdApi.MessageVideoNote -> {
+                context.getString(R.string.Video)
+            }
             is TdApi.MessageVoiceNote -> {
                 val caption = content.caption.text.replace('\n', ' ')
                 val text = context.getString(R.string.Voice) + " " + caption
@@ -940,6 +943,7 @@ class TgApiForPushNotification(private val context: Context) {
         return when (content) {
             is TdApi.PushMessageContentText -> limit(content.text)
             is TdApi.PushMessageContentPhoto -> context.getString(R.string.Photo) + " " + limit(content.caption)
+            is TdApi.PushMessageContentVideoNote -> context.getString(R.string.Video)
             is TdApi.PushMessageContentVoiceNote -> context.getString(R.string.Voice)
             is TdApi.PushMessageContentVideo -> context.getString(R.string.Video) + " " + limit(content.caption)
             is TdApi.PushMessageContentAnimation -> context.getString(R.string.Animation) + " " + limit(content.caption)

--- a/app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt
@@ -34,6 +34,7 @@ fun TgApi.handleAllPushMessages(content: TdApi.PushMessageContent): String {
     return when (content) {
         is TdApi.PushMessageContentText -> limit(content.text)
         is TdApi.PushMessageContentPhoto -> context.getString(R.string.Photo) + " " + limit(content.caption)
+        is TdApi.PushMessageContentVideoNote -> context.getString(R.string.Video)
         is TdApi.PushMessageContentVoiceNote -> context.getString(R.string.Voice)
         is TdApi.PushMessageContentVideo -> context.getString(R.string.Video) + " " + limit(content.caption)
         is TdApi.PushMessageContentAnimation -> context.getString(R.string.Animation) + " " + limit(content.caption)
@@ -73,6 +74,11 @@ fun TgApi.handleAllMessages(
             append(" ")
             val caption = content.caption.text.replace('\n', ' ')
             append(if (caption.length > maxText) caption.take(maxText) + "..." else caption)
+        }
+        is TdApi.MessageVideoNote -> buildAnnotatedString {
+            withStyle(style = SpanStyle(color = Color(context.getColor(R.color.blue)))) {
+                append(context.getString(R.string.Video))
+            }
         }
         is TdApi.MessageVoiceNote -> buildAnnotatedString {
             withStyle(style = SpanStyle(color = Color(context.getColor(R.color.blue)))) {


### PR DESCRIPTION
### Motivation
- Video notes were rendered correctly in the open chat UI but fell through to `Unknown_Message` in the shared summary helpers used for chat list rows, forwards and notifications, so video notes appeared unsupported outside the chat view.

### Description
- Add `TdApi.MessageVideoNote` handling to the shared `handleAllMessages` renderer in `app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt` so chat rows and forward previews show a `Video` label instead of `Unknown_Message`.
- Add `TdApi.PushMessageContentVideoNote` handling to the shared `handleAllPushMessages` helper in `app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt` to include video notes in push-preview text.
- Mirror both `MessageVideoNote` and `PushMessageContentVideoNote` branches in `app/src/main/java/com/gohj99/tgwear/utils/notification/TgApiForPushNotification.kt` so notification-only flows produce the same summaries.

### Testing
- Attempted to run `bash ./gradlew :app:compileDebugKotlin` but the Gradle wrapper failed to download `gradle-8.13-bin.zip` due to the environment proxy returning `403 Forbidden`, and `./gradlew` was not executable in the environment, so a full Kotlin build could not be performed.
- Ran repository searches (`rg`) to verify the new `MessageVideoNote`/`PushMessageContentVideoNote` branches are present in the intended files and updated all relevant summary paths, and then committed the changes (`Handle video note message summaries`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6a346a24833391b78ce91a053832)