### PR TITLE
feat: add Android 7 support, app lock, image send, audio handling, and secret chat entry

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.gohj99.tgwear"
-        minSdk = 26
+        minSdk = 24
         //noinspection OldTargetApi
         targetSdk = 34
         versionCode = 48

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
 
     <uses-feature
@@ -53,6 +52,12 @@
             android:showWhenLocked="true"
             android:turnScreenOn="true"
             android:excludeFromRecents="true"
+            android:theme="@style/Theme.TGwear" />
+        <activity
+            android:name=".AppLockActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:taskAffinity=""
             android:theme="@style/Theme.TGwear" />
         <activity
             android:name=".AddProxyActivity"

--- a/app/src/main/java/com/gohj99/tgwear/AppLockActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/AppLockActivity.kt
@@ -1,0 +1,116 @@
+package com.gohj99.tgwear
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.gohj99.tgwear.ui.CustomButton
+import com.gohj99.tgwear.ui.theme.TGwearTheme
+
+class AppLockActivity : BaseActivity() {
+    private var promptStarted = false
+
+    private val unlockLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                AppLockManager.unlock()
+                finish()
+            } else {
+                AppLockManager.cancelPrompt()
+                moveTaskToBack(true)
+                finish()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            TGwearTheme {
+                AppLockScreen(
+                    onUnlock = { requestUnlock() }
+                )
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!promptStarted) {
+            promptStarted = true
+            requestUnlock()
+        }
+    }
+
+    private fun requestUnlock() {
+        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        if (!keyguardManager.isDeviceSecure) {
+            Toast.makeText(this, getString(R.string.app_lock_requires_device_lock), Toast.LENGTH_SHORT).show()
+            val prefs = getSharedPreferences("app_settings", MODE_PRIVATE)
+            prefs.edit().putBoolean("app_lock_enabled", false).apply()
+            AppLockManager.unlock()
+            finish()
+            return
+        }
+
+        val intent = keyguardManager.createConfirmDeviceCredentialIntent(
+            getString(R.string.app_lock_title),
+            getString(R.string.app_lock_description)
+        )
+
+        if (intent == null) {
+            AppLockManager.unlock()
+            finish()
+            return
+        }
+
+        unlockLauncher.launch(intent)
+    }
+}
+
+@Composable
+private fun AppLockScreen(onUnlock: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .padding(horizontal = 18.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(R.string.app_lock_title),
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = stringResource(R.string.app_lock_description),
+            color = Color(0xFF9BA7B4),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 10.dp, bottom = 18.dp)
+        )
+        CustomButton(
+            text = stringResource(R.string.app_lock_unlock),
+            onClick = onUnlock
+        )
+    }
+}

--- a/app/src/main/java/com/gohj99/tgwear/AppLockManager.kt
+++ b/app/src/main/java/com/gohj99/tgwear/AppLockManager.kt
@@ -1,0 +1,46 @@
+package com.gohj99.tgwear
+
+import android.content.Context
+
+object AppLockManager {
+    private var locked = false
+    private var promptShowing = false
+
+    fun isEnabled(context: Context): Boolean {
+        val prefs = context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+        return prefs.getBoolean("app_lock_enabled", false)
+    }
+
+    fun lock() {
+        locked = true
+    }
+
+    fun unlock() {
+        locked = false
+        promptShowing = false
+    }
+
+    fun cancelPrompt() {
+        promptShowing = false
+    }
+
+    fun markPromptShowing() {
+        promptShowing = true
+    }
+
+    fun shouldPrompt(context: Context): Boolean {
+        if (!isEnabled(context)) {
+            locked = false
+            promptShowing = false
+            return false
+        }
+
+        val currentActivityName = context::class.java.simpleName
+        if (currentActivityName == AppLockActivity::class.java.simpleName ||
+            currentActivityName == VoiceCallActivity::class.java.simpleName) {
+            return false
+        }
+
+        return locked && !promptShowing
+    }
+}

--- a/app/src/main/java/com/gohj99/tgwear/Application.kt
+++ b/app/src/main/java/com/gohj99/tgwear/Application.kt
@@ -9,6 +9,7 @@
 package com.gohj99.tgwear
 
 import android.app.Application
+import android.os.Bundle
 
 class Application : Application() {
 
@@ -20,6 +21,30 @@ class Application : Application() {
     override fun onCreate() {
         super.onCreate()
         application = this
+        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+            private var startedActivityCount = 0
+
+            override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: Bundle?) = Unit
+
+            override fun onActivityStarted(activity: android.app.Activity) {
+                startedActivityCount += 1
+            }
+
+            override fun onActivityResumed(activity: android.app.Activity) = Unit
+
+            override fun onActivityPaused(activity: android.app.Activity) = Unit
+
+            override fun onActivityStopped(activity: android.app.Activity) {
+                startedActivityCount = (startedActivityCount - 1).coerceAtLeast(0)
+                if (startedActivityCount == 0) {
+                    AppLockManager.lock()
+                }
+            }
+
+            override fun onActivitySaveInstanceState(activity: android.app.Activity, outState: Bundle) = Unit
+
+            override fun onActivityDestroyed(activity: android.app.Activity) = Unit
+        })
     }
 
     init {
@@ -27,11 +52,9 @@ class Application : Application() {
         System.loadLibrary("tgcallsjni")
         System.loadLibrary("leveldbjni")
         System.loadLibrary("tgxjni")
-        System.loadLibrary("tgcallsjni") // 重复加载一次可能没必要，可以去掉
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             throwable.printStackTrace()
         }
     }
 }
-

--- a/app/src/main/java/com/gohj99/tgwear/BaseActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/BaseActivity.kt
@@ -9,6 +9,7 @@
 package com.gohj99.tgwear
 
 import android.content.Context
+import android.content.Intent
 import androidx.activity.ComponentActivity
 
 abstract class BaseActivity : ComponentActivity() {
@@ -24,5 +25,19 @@ abstract class BaseActivity : ComponentActivity() {
             else LocaleHelper.setLocale(newBase, lang)
             super.attachBaseContext(ctx)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!AppLockManager.shouldPrompt(this)) {
+            return
+        }
+
+        AppLockManager.markPromptShowing()
+        startActivity(
+            Intent(this, AppLockActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+        )
     }
 }

--- a/app/src/main/java/com/gohj99/tgwear/ChatActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ChatActivity.kt
@@ -345,6 +345,13 @@ class ChatActivity : BaseActivity() {
                                         is TdApi.MessageVoiceNote -> {
                                             println("语音消息")
                                         }
+
+                                        is TdApi.MessageAudio -> {
+                                            println("音频消息")
+                                            val intent = Intent(this, ViewActivity::class.java)
+                                            intent.putExtra("messageId", message.id)
+                                            startActivity(intent)
+                                        }
                                     }
                                 },
                                 longPress = { select, message ->

--- a/app/src/main/java/com/gohj99/tgwear/ChatInfoActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ChatInfoActivity.kt
@@ -9,6 +9,7 @@
 package com.gohj99.tgwear
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
@@ -21,6 +22,7 @@ import com.gohj99.tgwear.ui.theme.TGwearTheme
 import com.gohj99.tgwear.utils.formatTimestampToDateAndIntuitive
 import com.gohj99.tgwear.utils.telegram.TgApi
 import com.gohj99.tgwear.utils.telegram.createCall
+import com.gohj99.tgwear.utils.telegram.createSecretChat
 import com.gohj99.tgwear.utils.telegram.deleteChat
 import com.gohj99.tgwear.utils.telegram.getBasicGroup
 import com.gohj99.tgwear.utils.telegram.getBasicGroupFullInfo
@@ -140,6 +142,9 @@ class ChatInfoActivity : BaseActivity() {
                         }
                     }
                 }
+                is TdApi.ChatTypeSecret -> {
+                    subtitle = getString(R.string.Secret_chat)
+                }
 
                 // 普通群组
                 is TdApi.ChatTypeBasicGroup -> {
@@ -224,6 +229,29 @@ class ChatInfoActivity : BaseActivity() {
                                 },
                                 onVoiceCall = {
                                     tgApi!!.createCall(safeChat.id)
+                                },
+                                onSecretChat = {
+                                    lifecycleScope.launch(Dispatchers.IO) {
+                                        val secretChat = tgApi!!.createSecretChat(chatType.userId)
+                                        launch(Dispatchers.Main) {
+                                            if (secretChat == null) {
+                                                Toast.makeText(this@ChatInfoActivity, getString(R.string.Secret_chat_failed), Toast.LENGTH_SHORT).show()
+                                                return@launch
+                                            }
+
+                                            startActivity(
+                                                android.content.Intent(this@ChatInfoActivity, ChatActivity::class.java).apply {
+                                                    putExtra(
+                                                        "chat",
+                                                        Chat(
+                                                            id = secretChat.id,
+                                                            title = secretChat.title
+                                                        )
+                                                    )
+                                                }
+                                            )
+                                        }
+                                    }
                                 }
                             )
                         }

--- a/app/src/main/java/com/gohj99/tgwear/CheckUpdateActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/CheckUpdateActivity.kt
@@ -61,8 +61,9 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.File
 import java.io.IOException
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
 
 class CheckUpdateActivity : BaseActivity() {
@@ -118,10 +119,7 @@ class CheckUpdateActivity : BaseActivity() {
                                 val localVersion = pInfo.versionName
                                 val needsUpdate = compareVersions(version, localVersion.toString())
 
-                                val publishedAt = releaseInfo.publishedAt
-                                val zonedDateTime = ZonedDateTime.parse(publishedAt)
-                                val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-                                val formattedPublishedAt = zonedDateTime.format(formatter)
+                                val formattedPublishedAt = formatGithubPublishedAt(releaseInfo.publishedAt)
 
                                 val armAsset =
                                     releaseInfo.assets.find { it.name.contains("arm.apk") }
@@ -200,6 +198,19 @@ class CheckUpdateActivity : BaseActivity() {
                     }
                 }
             }
+        }
+    }
+
+    private fun formatGithubPublishedAt(publishedAt: String): String {
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+            val outputFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+            val date = inputFormat.parse(publishedAt) ?: return publishedAt
+            outputFormat.format(date)
+        } catch (e: Exception) {
+            publishedAt
         }
     }
 

--- a/app/src/main/java/com/gohj99/tgwear/LoginActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/LoginActivity.kt
@@ -323,7 +323,7 @@ class LoginActivity : BaseActivity() {
                             deviceModel = Build.MODEL
                             systemVersion = Build.VERSION.RELEASE
                             applicationVersion = appVersion
-                            useSecretChats = false
+                            useSecretChats = true
                             useMessageDatabase = true
                             useChatInfoDatabase = true
                             useFileDatabase = false

--- a/app/src/main/java/com/gohj99/tgwear/SettingActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/SettingActivity.kt
@@ -298,6 +298,21 @@ class SettingActivity : BaseActivity() {
                 title = getString(R.string.App_setting)
                 settingsList.value = listOf(
                     SettingItem.Switch(
+                        itemName = getString(R.string.app_lock),
+                        isSelected = settingsSharedPref.getBoolean("app_lock_enabled", false),
+                        onSelect = { appLockEnabled ->
+                            with(settingsSharedPref.edit()) {
+                                putBoolean("app_lock_enabled", appLockEnabled)
+                                apply()
+                            }
+                            if (appLockEnabled) {
+                                AppLockManager.unlock()
+                            } else {
+                                AppLockManager.unlock()
+                            }
+                        }
+                    ),
+                    SettingItem.Switch(
                         itemName = getString(R.string.Vibration_crown_turned),
                         isSelected = settingsSharedPref.getBoolean("Vibration_crown_turned", true),
                         onSelect = { vibration ->

--- a/app/src/main/java/com/gohj99/tgwear/ViewActivity.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ViewActivity.kt
@@ -22,9 +22,12 @@ import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +35,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,9 +59,12 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.gohj99.tgwear.model.tgFile
+import com.gohj99.tgwear.ui.CustomButton
 import com.gohj99.tgwear.ui.main.ErrorScreen
 import com.gohj99.tgwear.ui.main.SplashLoadingScreen
 import com.gohj99.tgwear.ui.theme.TGwearTheme
+import com.gohj99.tgwear.utils.formatDuration
+import com.gohj99.tgwear.utils.telegram.downloadFile
 import com.gohj99.tgwear.utils.telegram.TgApi
 import com.gohj99.tgwear.utils.telegram.downloadPhoto
 import com.gohj99.tgwear.utils.telegram.getMessageTypeById
@@ -208,6 +215,21 @@ class ViewActivity : BaseActivity() {
                             }
                         }
 
+                        is TdApi.MessageAudio -> {
+                            val audioFile = content.audio.audio
+                            if (!audioFile.local.isDownloadingCompleted) {
+                                tgApi?.downloadFile(audioFile, completion = { isSuccess, path ->
+                                    if (isSuccess) {
+                                        showAudio(path ?: audioFile.local.path, content.audio.fileName, content.audio.duration)
+                                    } else {
+                                        showError()
+                                    }
+                                })
+                            } else {
+                                showAudio(audioFile.local.path, content.audio.fileName, content.audio.duration)
+                            }
+                        }
+
                         else -> showError()
                     }
                 }
@@ -268,6 +290,18 @@ class ViewActivity : BaseActivity() {
         setContent {
             TGwearTheme {
                 SplashMp4View(photoPath)
+            }
+        }
+    }
+
+    private fun showAudio(audioPath: String, fileName: String, duration: Int) {
+        setContent {
+            TGwearTheme {
+                SplashAudioView(
+                    audioPath = audioPath,
+                    title = fileName.ifBlank { getString(R.string.Audio) },
+                    duration = duration
+                )
             }
         }
     }
@@ -420,6 +454,65 @@ private fun SplashMp4View(photoPath: String) {
         contentAlignment = Alignment.Center
     ) {
         LoopingVideoPlayer(Uri.parse(photoPath))
+    }
+}
+
+@Composable
+private fun SplashAudioView(audioPath: String, title: String, duration: Int) {
+    val context = LocalContext.current
+    val exoPlayer = remember {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(Uri.fromFile(File(audioPath))))
+            prepare()
+        }
+    }
+    var isPlaying by remember { mutableStateOf(false) }
+    var currentPosition by remember { mutableLongStateOf(0L) }
+
+    androidx.compose.runtime.LaunchedEffect(isPlaying) {
+        while (isPlaying) {
+            currentPosition = exoPlayer.currentPosition
+            delay(250)
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            exoPlayer.release()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+    ) {
+        Text(
+            text = title,
+            color = Color.White,
+            fontSize = 16.sp
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = "${formatDuration((currentPosition / 1000).toInt())} / ${formatDuration(duration)}",
+            color = Color(0xFF9BA7B4),
+            fontSize = 14.sp
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        CustomButton(
+            text = if (isPlaying) context.getString(R.string.Pause) else context.getString(R.string.Play),
+            onClick = {
+                if (isPlaying) {
+                    exoPlayer.pause()
+                    isPlaying = false
+                } else {
+                    exoPlayer.play()
+                    isPlaying = true
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/gohj99/tgwear/ui/ChatInfoScreen.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ui/ChatInfoScreen.kt
@@ -71,7 +71,8 @@ fun SplashChatInfoScreen(
     subtitle: String,
     info: String,
     deleteChat: (() -> Unit)? = null,
-    onVoiceCall: (() -> Unit)? = null
+    onVoiceCall: (() -> Unit)? = null,
+    onSecretChat: (() -> Unit)? = null
 ) {
     val gson = Gson()
     var messageJson = ""
@@ -240,6 +241,28 @@ fun SplashChatInfoScreen(
                             text = stringResource(R.string.Voice_call),
                             onClick = {
                                 onVoiceCall()
+                            }
+                        )
+                    }
+                }
+            }
+            if (onSecretChat != null) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(
+                                Color.Black.copy(alpha = 0.8f),
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            .padding(7.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CustomButton(
+                            text = stringResource(R.string.Open_secret_chat),
+                            onClick = {
+                                onSecretChat()
                             }
                         )
                     }

--- a/app/src/main/java/com/gohj99/tgwear/ui/chat/MessageDrawer.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ui/chat/MessageDrawer.kt
@@ -318,6 +318,26 @@ fun messageDrawer(
                 modifier = modifier
             )
         }
+        is TdApi.MessageAudio -> {
+            MessageAudio(
+                content = content,
+                stateDownload = stateDownload,
+                stateDownloadDone = stateDownloadDone,
+                modifier = modifier
+            )
+
+            content.caption?.text?.let {
+                SelectionContainer {
+                    FormattedText(
+                        text = it,
+                        entities = content.caption.entities,
+                        modifier = modifier,
+                        style = MaterialTheme.typography.bodyMedium,
+                        onEntityClick = onEntityClick
+                    )
+                }
+            }
+        }
         // 文件消息
         is TdApi.MessageDocument -> {
             MessageFile(

--- a/app/src/main/java/com/gohj99/tgwear/ui/chat/MessageFile.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ui/chat/MessageFile.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.gohj99.tgwear.R
 import com.gohj99.tgwear.TgApiManager.tgApi
+import com.gohj99.tgwear.utils.formatDuration
 import com.gohj99.tgwear.utils.formatSize
 import com.gohj99.tgwear.utils.telegram.cancelDownloadFile
 import com.gohj99.tgwear.utils.telegram.downloadFile
@@ -47,16 +48,56 @@ fun MessageFile(
     stateDownloadDone: MutableState<Boolean>,
     modifier: Modifier = Modifier
 ){
+    AttachmentMessageItem(
+        file = content.document.document,
+        fileName = content.document.fileName,
+        fileSize = content.document.document.size.toLong(),
+        extraText = null,
+        stateDownload = stateDownload,
+        stateDownloadDone = stateDownloadDone,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun MessageAudio(
+    content: TdApi.MessageAudio,
+    stateDownload: MutableState<Boolean>,
+    stateDownloadDone: MutableState<Boolean>,
+    modifier: Modifier = Modifier
+) {
+    val audio = content.audio
+    val duration = if (audio.duration > 0) formatDuration(audio.duration) else null
+    AttachmentMessageItem(
+        file = audio.audio,
+        fileName = audio.fileName.ifBlank {
+            listOf(audio.performer, audio.title).filter { it.isNotBlank() }.joinToString(" - ")
+                .ifBlank { "audio.mp3" }
+        },
+        fileSize = audio.audio.size.toLong(),
+        extraText = duration,
+        stateDownload = stateDownload,
+        stateDownloadDone = stateDownloadDone,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AttachmentMessageItem(
+    file: TdApi.File,
+    fileName: String,
+    fileSize: Long,
+    extraText: String?,
+    stateDownload: MutableState<Boolean>,
+    stateDownloadDone: MutableState<Boolean>,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
-    val document = content.document
-    val file = document.document
     var fileUrl by remember { mutableStateOf(file.local.path) }
-    val fileName = document.fileName
-    val fileSize = file.size
     var downloadSchedule by remember { mutableStateOf(file.local.downloadedSize) }
 
     // 检查文件状态
-    LaunchedEffect(document) {
+    LaunchedEffect(file.id) {
         if (file.local.isDownloadingCompleted) {
             stateDownloadDone.value = true
         } else {
@@ -127,6 +168,14 @@ fun MessageFile(
                 style = MaterialTheme.typography.bodySmall,
                 modifier = modifier
             )
+            if (!extraText.isNullOrBlank()) {
+                Text(
+                    text = extraText,
+                    color = Color(0xFF8FA3B8),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = modifier
+                )
+            }
             Spacer(modifier = Modifier.width(12.dp))
             Text(
                 text =

--- a/app/src/main/java/com/gohj99/tgwear/ui/chat/SendMessageCompose.kt
+++ b/app/src/main/java/com/gohj99/tgwear/ui/chat/SendMessageCompose.kt
@@ -9,8 +9,11 @@
 package com.gohj99.tgwear.ui.chat
 
 import android.Manifest
+import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
 import android.media.MediaRecorder
+import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -80,6 +83,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.drinkless.tdlib.TdApi
 import java.io.File
+import java.io.FileOutputStream
 
 @Composable
 fun SendMessageCompose(
@@ -356,6 +360,50 @@ fun SendMessageCompose(
     ) { isGranted ->
         if (isGranted) {
             // 授权后逻辑，可选：直接开始录音
+        }
+    }
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri == null) {
+            return@rememberLauncherForActivityResult
+        }
+
+        val cacheFile = copyImageUriToCache(context, uri) ?: return@rememberLauncherForActivityResult
+        val (imageWidth, imageHeight) = readImageSize(cacheFile)
+        val replyTo = planReplyMessage.value?.let { replyMessage ->
+            if (replyMessage.chatId != chatId) {
+                TdApi.InputMessageReplyToExternalMessage(replyMessage.chatId, replyMessage.id, null)
+            } else {
+                TdApi.InputMessageReplyToMessage(replyMessage.id, null)
+            }
+        }
+
+        tgApi?.sendMessage(
+            chatId = chatId,
+            message = TdApi.InputMessagePhoto().apply {
+                photo = TdApi.InputFileLocal().apply {
+                    path = cacheFile.absolutePath
+                }
+                width = imageWidth
+                height = imageHeight
+                addedStickerFileIds = intArrayOf()
+                caption = TdApi.FormattedText().apply {
+                    text = inputText.value
+                }
+            },
+            replyTo = replyTo,
+            messageThreadId = selectTopicId.value
+        )
+
+        inputText.value = ""
+        planReplyMessage.value = null
+        tgApi?.replyMessage?.value = null
+
+        coroutineScope.launch {
+            pagerState.animateScrollToPage(0)
+            listState.animateScrollToItem(0)
         }
     }
 
@@ -761,6 +809,20 @@ fun SendMessageCompose(
                     )
                 }
 
+                IconButton(
+                    onClick = {
+                        imagePickerLauncher.launch("image/*")
+                    },
+                    modifier = Modifier.size(45.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.Send_photo).take(1),
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
                 // 中：录制按钮
                 IconButton(
                     onClick = {
@@ -919,4 +981,29 @@ fun SendMessageCompose(
         }
     }
     Spacer(modifier = Modifier.height(80.dp))
+}
+
+private fun copyImageUriToCache(context: Context, uri: Uri): File? {
+    val extension = context.contentResolver.getType(uri)
+        ?.substringAfterLast('/', "jpg")
+        ?.ifBlank { "jpg" }
+        ?: "jpg"
+    val outputFile = File(context.cacheDir, "picked_image_${System.currentTimeMillis()}.$extension")
+
+    return runCatching {
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            FileOutputStream(outputFile).use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        } ?: return null
+        outputFile
+    }.getOrNull()
+}
+
+private fun readImageSize(file: File): Pair<Int, Int> {
+    val options = BitmapFactory.Options().apply {
+        inJustDecodeBounds = true
+    }
+    BitmapFactory.decodeFile(file.absolutePath, options)
+    return options.outWidth.coerceAtLeast(0) to options.outHeight.coerceAtLeast(0)
 }

--- a/app/src/main/java/com/gohj99/tgwear/utils/notification/TgApiForPushNotification.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/notification/TgApiForPushNotification.kt
@@ -89,7 +89,7 @@ class TgApiForPushNotification(private val context: Context) {
             deviceModel = Build.MODEL
             systemVersion = Build.VERSION.RELEASE
             applicationVersion = getAppVersion(context)
-            useSecretChats = false
+            useSecretChats = true
             useMessageDatabase = true
             useChatInfoDatabase = true
             useFileDatabase = false
@@ -899,6 +899,17 @@ class TgApiForPushNotification(private val context: Context) {
             is TdApi.MessageVoiceNote -> {
                 val caption = content.caption.text.replace('\n', ' ')
                 val text = context.getString(R.string.Voice) + " " + caption
+                if (text.length > maxText) text.take(maxText) + "..." else text
+            }
+            is TdApi.MessageAudio -> {
+                val audioName = content.audio.fileName
+                    .ifBlank {
+                        listOf(content.audio.performer, content.audio.title)
+                            .filter { it.isNotBlank() }
+                            .joinToString(" ")
+                    }
+                    .replace('\n', ' ')
+                val text = context.getString(R.string.Audio) + " " + audioName
                 if (text.length > maxText) text.take(maxText) + "..." else text
             }
             is TdApi.MessageAnimation -> {

--- a/app/src/main/java/com/gohj99/tgwear/utils/telegram/SendRequest.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/telegram/SendRequest.kt
@@ -260,6 +260,15 @@ suspend fun TgApi.getMessageTypeById(messageId: Long, chatId: Long = saveChatId)
     }
 }
 
+suspend fun TgApi.createSecretChat(userId: Long): TdApi.Chat? {
+    return try {
+        val result = sendRequest(TdApi.CreateNewSecretChat(userId))
+        if (result is TdApi.Chat) result else null
+    } catch (e: Exception) {
+        null
+    }
+}
+
 // 10. 强制加载消息
 internal fun TgApi.addNewChat(chatId: Long){
     // 异步获取聊天标题

--- a/app/src/main/java/com/gohj99/tgwear/utils/telegram/TgApi.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/telegram/TgApi.kt
@@ -82,7 +82,7 @@ class TgApi(
             deviceModel = Build.MODEL
             systemVersion = Build.VERSION.RELEASE
             applicationVersion = getAppVersion(context)
-            useSecretChats = false
+            useSecretChats = true
             useMessageDatabase = true
             useChatInfoDatabase = true
             useFileDatabase = false

--- a/app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt
+++ b/app/src/main/java/com/gohj99/tgwear/utils/telegram/Utils.kt
@@ -34,6 +34,7 @@ fun TgApi.handleAllPushMessages(content: TdApi.PushMessageContent): String {
     return when (content) {
         is TdApi.PushMessageContentText -> limit(content.text)
         is TdApi.PushMessageContentPhoto -> context.getString(R.string.Photo) + " " + limit(content.caption)
+        is TdApi.PushMessageContentAudio -> context.getString(R.string.Audio) + " " + limit(content.audio.fileName)
         is TdApi.PushMessageContentVoiceNote -> context.getString(R.string.Voice)
         is TdApi.PushMessageContentVideo -> context.getString(R.string.Video) + " " + limit(content.caption)
         is TdApi.PushMessageContentAnimation -> context.getString(R.string.Animation) + " " + limit(content.caption)
@@ -81,6 +82,20 @@ fun TgApi.handleAllMessages(
             append(" ")
             val caption = content.caption.text.replace('\n', ' ')
             append(if (caption.length > maxText) caption.take(maxText) + "..." else caption)
+        }
+        is TdApi.MessageAudio -> buildAnnotatedString {
+            withStyle(style = SpanStyle(color = Color(context.getColor(R.color.blue)))) {
+                append(context.getString(R.string.Audio))
+            }
+            append(" ")
+            val audioName = content.audio.fileName
+                .ifBlank {
+                    listOf(content.audio.performer, content.audio.title)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" ")
+                }
+                .replace('\n', ' ')
+            append(if (audioName.length > maxText) audioName.take(maxText) + "..." else audioName)
         }
         is TdApi.MessageAnimation -> buildAnnotatedString {
             withStyle(style = SpanStyle(color = Color(context.getColor(R.color.blue)))) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,6 +53,7 @@
     <string name="No_need_to_save">无需保存</string>  
     <string name="Download">下载</string>  
     <string name="Play">播放</string>  
+    <string name="Pause">暂停</string>
     <string name="Clear_cache">清除缓存</string>  
     <string name="Clear_thumbnails">清除缩略图</string>  
     <string name="Clear_photos">清除照片</string>  
@@ -108,6 +109,11 @@
     <string name="Beta_description">该版本为测试版本\n可能存在错误</string>  
     <string name="is_home_page_pin">是否获取首页置顶消息（可能有bug）</string>  
     <string name="show_unknown_message_type">显示不支持的消息类型</string>  
+    <string name="app_lock">应用锁</string>
+    <string name="app_lock_title">解锁 TGwear</string>
+    <string name="app_lock_description">请使用手表的密码、图案或 PIN 继续。</string>
+    <string name="app_lock_unlock">解锁</string>
+    <string name="app_lock_requires_device_lock">请先给设备设置锁屏，再开启应用锁。</string>
     <string name="GoToCheckUpdateActivity_title">检查更新警告</string>  
     <string name="GoToCheckUpdateActivity_description">我们将从官方 GitHub 存储库检查更新。\n如果您从 IzzyOnDroid/F-Droid 等安装了应用程序，则不会运行它们的软件附加检查。</string>  
     <string name="don_remind_me_again">不要再提醒我</string>  
@@ -202,6 +208,11 @@
     <string name="Login_With_QR">二维码登录</string>  
     <string name="Connecting_Telegram_Sever">连接到电报服务器…\n中国大陆内无法使用</string>  
     <string name="Topic">话题</string>  
+    <string name="Audio">音频</string>
+    <string name="Send_photo">发送图片</string>
+    <string name="Secret_chat">端到端聊天</string>
+    <string name="Open_secret_chat">打开端到端聊天</string>
+    <string name="Secret_chat_failed">创建端到端聊天失败</string>
     <string name="Remind5">你好！\n欢迎使用 TGwear 应用！\n\n我们强烈建议您完整阅读以下使用说明，以避免不必要的问题。\n\n首先，欢迎加入我们的官方 Telegram 支持群，点击以下链接即可加入：\nhttps://t.me/teleTGwear\n\n以下是快速入门指南：\n\n首次使用时，请在“设置 → UI”中手动调整显示缩放比例，以获得最佳视图效果。\n长按消息边框或发送者姓名可打开更多操作选项。\n在聊天界面中，向左滑动可进入消息发送页面；点击顶部标题可查看该聊天的详细信息。\n在部分界面中，长按并拖动文字可进行选择和复制。\n在图片查看器中，长按图片可将其保存到您的图库。\n\n在代理页面，长按某一条代理项即可将其删除。\n在回复或转发模式下，点击上方的“回复”或“转发”标题可退出该模式。\n\nTGwear 是开源项目，您可以通过 GitHub 请求获取其源代码。</string>  
     <string name="joined_the_group">加入了小组</string>  
     <string name="data_collection_description">我们使用Firebase Crashlytics匿名收集崩溃报告，跟踪最常用的功能，并收集使用模式数据以使TGwear更加用户友好。您可以在设置中的任何时间禁用此功能。</string>  

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="No_need_to_save">No need to save</string>
     <string name="Download">Download</string>
     <string name="Play">Play</string>
+    <string name="Pause">Pause</string>
     <string name="Clear_cache">Clear cache</string>
     <string name="Clear_thumbnails">Clear thumbnails</string>
     <string name="Clear_photos">Clear photos</string>
@@ -120,6 +121,11 @@
     <string name="Beta_description">Change the version to a test version\nThere may be various bugs</string>
     <string name="is_home_page_pin">Whether to get the top message on the homepage (may have a bug)</string>
     <string name="show_unknown_message_type">Displays unsupported message types</string>
+    <string name="app_lock">App lock</string>
+    <string name="app_lock_title">Unlock TGwear</string>
+    <string name="app_lock_description">Use your watch PIN, password, or pattern to continue.</string>
+    <string name="app_lock_unlock">Unlock</string>
+    <string name="app_lock_requires_device_lock">Set a device lock first, then enable app lock.</string>
     <string name="GoToCheckUpdateActivity_title">Check updates warning</string>
     <string name="GoToCheckUpdateActivity_description">We will check for updates from the official GitHub repository.\nIf you installed the app from e.g. IzzyOnDroid/F-Droid, their additional checks will not be run.</string>
     <string name="don_remind_me_again">Don\'t remind me again</string>
@@ -215,6 +221,11 @@
     <string name="Login_With_QR">Login With QR</string>
     <string name="Connecting_Telegram_Sever">Connect to Telegram server…</string>
     <string name="Topic">Topic</string>
+    <string name="Audio">Audio</string>
+    <string name="Send_photo">Send photo</string>
+    <string name="Secret_chat">Secret chat</string>
+    <string name="Open_secret_chat">Open secret chat</string>
+    <string name="Secret_chat_failed">Failed to create secret chat</string>
     <string name="Remind5">Hello! \nWelcome to the TGwear app! \n\nWe recommend that you read the instructions in full to avoid any unnecessary issues.\n\nFirst, we suggest joining our official Telegram group for support. You can join by clicking the link below:\nhttps://t.me/teleTGwear\n\nHere’s a quick guide to help you get started:\n\nOn first use, please manually adjust the display scaling in the UI settings to ensure optimal viewing.\nLong-press the message border or the sender’s name to access additional options.\nIn the chat screen, swipe left to access the message composition interface; tap the header to view detailed information about the chat.\nOn applicable screens, long-press and drag to select and copy text.\nIn the image viewer, long-press an image to save it to your device’s gallery.\n\nOn the proxy page, long-press an entry to remove that proxy.\nIn reply or forward mode, tap the reply or forward title above to exit.\n\nTGwear is open-source, and you may request access to the source code on GitHub.</string>
     <string name="joined_the_group">joined the group</string>
     <string name="data_collection_description">We use Firebase Crashlytics to anonymously collect crash reports, track the most frequently used features, and gather usage pattern data to make TGwear more user-friendly. You can disable this feature at any time in the settings.</string>


### PR DESCRIPTION
## Summary
- lower `minSdk` to 24 and replace `java.time` usage in update checking for Android 7 compatibility
- add app lock based on the system device credential prompt
- add image sending from the chat composer
- add audio message rendering and playback entry, including MP3-friendly handling
- enable secret chats in TDLib and add a private-chat info entry button to create/open a secret chat

## Validation
- `git diff --check`
- full Gradle build not run in the current environment because `JAVA_HOME`/`java` is unavailable

## Notes
- changes are scoped for contribution review against `develop`
